### PR TITLE
Turn fixes

### DIFF
--- a/source/ChessHelpers/PositionDiffCalculator.cs
+++ b/source/ChessHelpers/PositionDiffCalculator.cs
@@ -28,7 +28,7 @@ namespace ChessHelpers
                                                       "1-0" : "0-1"));
 
                 //Getting the next move so return the opposite
-                return (move, ending, (board.Turn == PieceColor.White) ? "BLACK" : "WHITE");
+                return (move, ending, (board.Turn == PieceColor.White) ? "WHITE" : "BLACK");
             }
             catch (Exception)
             {

--- a/source/DgtCherub/Controllers/CherubVirtualClockController.cs
+++ b/source/DgtCherub/Controllers/CherubVirtualClockController.cs
@@ -332,7 +332,7 @@ namespace DgtCherub.Controllers
                 }));
             };
 
-            _angelHubService.OnRemoteFenChange += async (string fromRemoteFen, string toRemoteFen, string lastMove) =>
+            _angelHubService.OnRemoteFenChange += async (string fromRemoteFen, string toRemoteFen, string lastMove, string clockFen, string boardFen) =>
             {
                 await SendEventResponse(Response, JsonSerializer.Serialize(new
                 {

--- a/source/DgtCherub/Form1.cs
+++ b/source/DgtCherub/Form1.cs
@@ -298,9 +298,9 @@ namespace DgtCherub
                 DisplayBoardImages();
             };
 
-            _angelHubService.OnRemoteFenChange += (string fromRemoteFen, string toRemoteFen, string lastMove) =>
+            _angelHubService.OnRemoteFenChange += (string fromRemoteFen, string toRemoteFen, string lastMove, string clockFen, string boardFen) =>
             {
-                TextBoxConsole.AddLine($"Remote board changed to [{toRemoteFen}] from [{fromRemoteFen}] [{lastMove}]");
+                TextBoxConsole.AddLine($"Remote board changed to [{toRemoteFen}] from [{fromRemoteFen}] [{lastMove}] [clk={clockFen[..1]}::brd={boardFen[..1]}]");
                 DisplayBoardImages();
             };
 

--- a/source/DgtCherub/Form1.cs
+++ b/source/DgtCherub/Form1.cs
@@ -27,7 +27,7 @@ namespace DgtCherub
     public partial class Form1 : Form
     {
         private const int TEXTBOX_MAX_LINES = 200;
-        private const string VERSION_NUMBER = "0.4.3 PLAY-UAT-01";
+        private const string VERSION_NUMBER = "0.4.3 PLAY-UAT-02";
         private const string PROJECT_URL = "https://hyper-dragon.github.io/DgtAngel/";
         private const string VIRTUAL_CLOCK_PORT = "37964";
         private const string VIRTUAL_CLOCK_LINK = @$"http://127.0.0.1:{VIRTUAL_CLOCK_PORT}";

--- a/source/DgtCherub/Services/AngelHubService.cs
+++ b/source/DgtCherub/Services/AngelHubService.cs
@@ -94,7 +94,12 @@ namespace DgtCherub.Services
         private const int MS_IN_SEC = 1000;
 
         private const int MATCHER_REMOTE_TIME_DELAY_MS = 5000;
-        private const int MATCHER_LOCAL_TIME_DELAY_MS = 750;
+
+        //TODO: Keep the local matcher times the same for now as splitting
+        //      causes the clocks not to clear the mismatch message
+        //      Raise bug against this (low priority)
+        private const int MATCHER_LOCAL_TIME_DELAY_MS = 1500;
+        private const int MATCHER_LOCAL_TIME_DELAY_FROM_MISMATCH_MS = 1500;
 
         private const int POST_EVENT_DELAY_LAST_MOVE = MS_IN_SEC;
         private const int POST_EVENT_DELAY_LOCAL_FEN = MATCHER_LOCAL_TIME_DELAY_MS * 2;
@@ -269,15 +274,15 @@ namespace DgtCherub.Services
                 {
                     LocalBoardFEN = fen;
 
-                    //if (!IsBoardInSync && LocalBoardFEN == RemoteBoardFEN)
-                    //{
-                    if (IsLocalBoardAvailable && IsRemoteBoardAvailable)
+                    if (IsLocalBoardAvailable && 
+                       IsRemoteBoardAvailable)
                     {
                         // If the fens match we have caught up to the remote board.
                         // Run the matcher straight away to clear any outstanding match requests.
                         // There is no need to match after our moves - issues will be detected by the remote board match
                         CurrentUpdatetMatch = Guid.NewGuid();
-                        _ = Task.Run(() => TestForBoardMatch(CurrentUpdatetMatch.ToString(), MATCHER_LOCAL_TIME_DELAY_MS));
+                        _ = Task.Run(() => TestForBoardMatch(CurrentUpdatetMatch.ToString(), 
+                                           IsBoardInSync ? MATCHER_LOCAL_TIME_DELAY_MS: MATCHER_LOCAL_TIME_DELAY_FROM_MISMATCH_MS));
                     }
 
                     OnLocalFenChange?.Invoke(LocalBoardFEN);
@@ -423,8 +428,8 @@ namespace DgtCherub.Services
 
                 // The match code was captured when the method was called so compare to the outside value and
                 // if they are not the same we can skip as the local position has changed.
-                lock (matcherLockObj)
-                {
+                //lock (matcherLockObj)
+                //{
                     if (matchCode == CurrentUpdatetMatch.ToString())
                     {
                         _logger?.LogTrace("POST IN OUT", $"IN:{matchCode} OUT:{CurrentUpdatetMatch}");
@@ -450,7 +455,7 @@ namespace DgtCherub.Services
                     {
                         _logger?.LogTrace("CANX IN OUT", $"IN:{matchCode} OUT:{CurrentUpdatetMatch}");
                     }
-                }
+                //}
             }
         }
 

--- a/source/DgtCherub/Services/AngelHubService.cs
+++ b/source/DgtCherub/Services/AngelHubService.cs
@@ -40,7 +40,7 @@ namespace DgtCherub.Services
         event Action OnOrientationFlipped;
         event Action<string> OnPlayBlackClockAudio;
         event Action<string> OnPlayWhiteClockAudio;
-        event Action<string, string, string> OnRemoteFenChange;
+        event Action<string, string, string, string, string> OnRemoteFenChange;
         event Action<string, string> OnNotification;
 
         void LocalBoardUpdate(string fen);
@@ -53,7 +53,7 @@ namespace DgtCherub.Services
     public sealed class AngelHubService : IAngelHubService
     {
         public event Action<string> OnLocalFenChange;
-        public event Action<string, string, string> OnRemoteFenChange;
+        public event Action<string, string, string, string, string> OnRemoteFenChange;
         public event Action OnRemoteDisconnect;
         public event Action OnClockChange;
         public event Action OnOrientationFlipped;
@@ -363,9 +363,9 @@ namespace DgtCherub.Services
                     OnNotification?.Invoke("LMOVE", $"New move detected '{remoteBoardState.Board.LastMove}'");
 
                     // If turncode is none then read all moves
-                    bool isPlayerTurn = remoteBoardState.Board.ClockTurn == TurnCode.NONE ||
-                                          (IsWhiteOnBottom && remoteBoardState.Board.ClockTurn != TurnCode.WHITE) ||
-                                          (!IsWhiteOnBottom && remoteBoardState.Board.ClockTurn != TurnCode.BLACK);
+                    bool isPlayerTurn = remoteBoardState.Board.FenTurn == TurnCode.NONE ||
+                                          (IsWhiteOnBottom && remoteBoardState.Board.FenTurn != TurnCode.WHITE) ||
+                                          (!IsWhiteOnBottom && remoteBoardState.Board.FenTurn != TurnCode.BLACK);
 
                     OnNewMoveDetected?.Invoke(LastMove, isPlayerTurn);
 
@@ -403,7 +403,9 @@ namespace DgtCherub.Services
                     CurrentUpdatetMatch = Guid.NewGuid();
                     _ = Task.Run(() => TestForBoardMatch(CurrentUpdatetMatch.ToString(), MatcherRemoteTimeDelayMs));
 
-                    OnRemoteFenChange?.Invoke(FromRemoteBoardFEN, RemoteBoardFEN, LastMove);
+                    OnRemoteFenChange?.Invoke(FromRemoteBoardFEN, RemoteBoardFEN, LastMove, 
+                                              remoteBoardState.Board.ClockTurn.ToString(), 
+                                              remoteBoardState.Board.FenTurn.ToString());
                     await Task.Delay(POST_EVENT_DELAY_REMOTE_FEN);
                 }
             }


### PR DESCRIPTION
# Description

- Beep mode was using the Clock turn rather than the calculated turn
- Reverted the local matcher timings - need to create bug or enhancement?? to speed up the timer if the board is already mismatched.  At the moment it is fine in cherub but causes an issue with virtual clocks.

Fixes # (issue)

Closes #138
Closes #140

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
